### PR TITLE
Add HOST option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Server Configuration
+HOST=localhost
 PORT=3000
 BASE_URL=http://localhost:3000
 

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,5 @@
 # Production Environment Variables
+HOST=127.0.0.1
 PORT=3000
 BASE_URL=https://your-domain.com/file-service
 JWT_PUBLIC_KEY_PATH=/etc/ssl/certs/jwt-public-key.pem

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import documentRoutes from './routes/documents';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || 'localhost'; // Defaults to localhost if not specified
 
 // Remove the default Express fingerprinting header.
 app.disable('x-powered-by');
@@ -72,7 +73,6 @@ app.get('/health', (req, res) => {
   res.json({ status: 'OK', timestamp: new Date().toISOString() });
 });
 
-app.listen(PORT, () => {
-  console.log(`File sharing service running on port ${PORT}`);
-  console.log(`Health check: http://localhost:${PORT}/health`);
+app.listen(Number(PORT), HOST, () => {
+    console.log(`Server is running on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
Installing jitsi file sharing service natively without docker or pm2, we have no option to run the service with localhost / 127.0.0.1 binding. only port was available. the dirty solution is to block the defined port in .env by firewall, but its cleaner to configure the interface.

there is no need to expose file service to the outworld, as we install reverse proxy to front usually.